### PR TITLE
fix(security): remediate P0/P1 certification findings (auth, secrets, webhook, CI)

### DIFF
--- a/.github/workflows/ci-integration-services.yml
+++ b/.github/workflows/ci-integration-services.yml
@@ -61,16 +61,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # pnpm must be set up BEFORE setup-node, otherwise `cache: 'pnpm'` runs
+      # while pnpm is not yet on PATH ("Unable to locate executable file: pnpm").
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Install deps
         run: pnpm install

--- a/.github/workflows/ci-integration-services.yml
+++ b/.github/workflows/ci-integration-services.yml
@@ -43,7 +43,7 @@ jobs:
           --health-timeout=5s
           --health-retries=5
       minio:
-        image: minio/minio:RELEASE.2024-12-07T00-00-00Z
+        image: minio/minio:RELEASE.2024-12-18T13-15-44Z
         env:
           MINIO_ROOT_USER: minioadmin
           MINIO_ROOT_PASSWORD: minioadmin

--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -21,14 +21,15 @@ jobs:
       target_matrix: ${{ steps.generate_matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
+      # pnpm must be set up BEFORE setup-node so `cache: 'pnpm'` can find it.
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
           cache-dependency-path: pnpm-lock.yaml
-      - uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
       - run: corepack enable && corepack prepare pnpm@${{ env.PNPM_VERSION }}.0.0 --activate
       - run: pnpm install --frozen-lockfile
       - name: Save workspace info
@@ -69,14 +70,15 @@ NODE
         include: ${{ fromJson(needs.setup.outputs.target_matrix) }}
     steps:
       - uses: actions/checkout@v4
+      # pnpm must be set up BEFORE setup-node so `cache: 'pnpm'` can find it.
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
           cache-dependency-path: pnpm-lock.yaml
-      - uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
       - name: Setup pnpm store cache
         uses: actions/cache@v4
         with:

--- a/apps/web-site/tests/e2e/home.a11y.spec.ts
+++ b/apps/web-site/tests/e2e/home.a11y.spec.ts
@@ -3,7 +3,8 @@ import AxeBuilder from '@axe-core/playwright';
 
 test('home renders and has no critical a11y violations', async ({ page }) => {
   await page.goto('/');
-  await expect(page).toHaveTitle(/Arman Varzesh/i);
+  // The site title is Persian ("آرمان ورزش — …"); assert the real brand title.
+  await expect(page).toHaveTitle(/آرمان ورزش/);
 
   const accessibilityScanResults = await new AxeBuilder({ page })
     .withTags(['wcag2a', 'wcag2aa'])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1955,6 +1955,9 @@ importers:
       helmet:
         specifier: ^7.1.0
         version: 7.2.0
+      jsonwebtoken:
+        specifier: '>=9.0.0'
+        version: 9.0.2
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
@@ -2350,6 +2353,9 @@ importers:
       helmet:
         specifier: ^7.1.0
         version: 7.2.0
+      jsonwebtoken:
+        specifier: '>=9.0.0'
+        version: 9.0.2
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
@@ -2680,6 +2686,9 @@ importers:
       joi:
         specifier: ^17.10.1
         version: 17.13.3
+      jsonwebtoken:
+        specifier: '>=9.0.0'
+        version: 9.0.2
       nestjs-pino:
         specifier: ^4.0.0
         version: 4.4.1(@nestjs/common@11.1.4(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(pino-http@10.5.0)(pino@9.13.1)(rxjs@7.8.2)
@@ -2792,6 +2801,9 @@ importers:
       helmet:
         specifier: ^7.1.0
         version: 7.2.0
+      jsonwebtoken:
+        specifier: '>=9.0.0'
+        version: 9.0.2
       prom-client:
         specifier: ^15.1.1
         version: 15.1.3
@@ -3500,6 +3512,9 @@ importers:
       joi:
         specifier: ^17.10.1
         version: 17.13.3
+      jsonwebtoken:
+        specifier: '>=9.0.0'
+        version: 9.0.2
       nestjs-pino:
         specifier: ^4.0.0
         version: 4.4.1(@nestjs/common@11.1.4(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(pino-http@10.5.0)(pino@9.13.1)(rxjs@7.8.2)

--- a/services/activities-service/src/activities.service.ts
+++ b/services/activities-service/src/activities.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { getPrisma } from './prisma';
 
 function uid(): string { return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
   const r = Math.random()*16|0, v = c==='x'? r : (r&0x3|0x8); return v.toString(16);
@@ -38,7 +38,7 @@ function smoothTrack(points:{lat:number,lng:number,ts:number,elevM?:number}[]){
 
 @Injectable()
 export class ActivitiesService {
-  prisma = new PrismaClient();
+  prisma = getPrisma();
 
   async createRoute(userId: string, name: string, polyline: string, difficulty?: string, city?: string){
     if (!name || !polyline) throw new BadRequestException('MISSING_FIELDS');

--- a/services/activities-service/src/prisma.readiness.ts
+++ b/services/activities-service/src/prisma.readiness.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { getPrisma } from './prisma';
 
 @Injectable()
 export class PrismaReadiness {
-  private prisma = new PrismaClient();
+  private prisma = getPrisma();
   async ping(): Promise<boolean> {
     try {
       // SELECT 1; if DB is reachable, it should succeed

--- a/services/activities-service/src/prisma.ts
+++ b/services/activities-service/src/prisma.ts
@@ -1,0 +1,8 @@
+import { PrismaClient } from '@prisma/client';
+
+// Single shared PrismaClient for the service (P0-6): per-module/per-request
+// client instantiation exhausts the Postgres connection pool under load.
+let _prisma: PrismaClient | undefined;
+export function getPrisma(): PrismaClient {
+  return (_prisma ??= new PrismaClient());
+}

--- a/services/affiliate-service/package.json
+++ b/services/affiliate-service/package.json
@@ -12,6 +12,7 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
+    "jsonwebtoken": "^9.0.2",
     "@arman/observability-sdk": "workspace:*",
     "@nestjs/common": "^10.4.0",
     "@nestjs/core": "^10.4.0",

--- a/services/affiliate-service/src/affiliate.controller.ts
+++ b/services/affiliate-service/src/affiliate.controller.ts
@@ -2,6 +2,7 @@
 import { Controller, Get, Req } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { AffiliateService } from './affiliate.service';
+import { userIdFromReq } from './auth/req-user';
 
 @ApiTags('affiliate')
 @ApiBearerAuth()
@@ -11,7 +12,7 @@ export class AffiliateController {
 
   @Get('me')
   async me(@Req() req: any) {
-    const userId = Number(req.user?.id || req.headers['x-user-id'] || 1);
+    const userId = userIdFromReq(req);
     return this.svc.me(userId);
   }
 

--- a/services/affiliate-service/src/auth/req-user.ts
+++ b/services/affiliate-service/src/auth/req-user.ts
@@ -1,0 +1,30 @@
+import { UnauthorizedException } from '@nestjs/common';
+import * as jwt from 'jsonwebtoken';
+
+/**
+ * Numeric user id from a verified Bearer JWT. There is NO x-user-id header or
+ * query fallback (those allowed any caller to act as any user) and NO fallback
+ * secret. JWT_SECRET is required; verification pins HS256. Throws 401 when the
+ * token is missing or invalid.
+ */
+function jwtSecret(): string {
+  const s = process.env.JWT_SECRET;
+  if (!s || s.length < 16) {
+    throw new Error('JWT_SECRET is not configured (minimum 16 characters required)');
+  }
+  return s;
+}
+
+export function userIdFromReq(req: any): number {
+  const auth = (req?.headers?.authorization || '').toString();
+  if (!auth.startsWith('Bearer ')) throw new UnauthorizedException('missing bearer token');
+  let claims: any;
+  try {
+    claims = jwt.verify(auth.slice(7), jwtSecret(), { algorithms: ['HS256'] });
+  } catch {
+    throw new UnauthorizedException('invalid token');
+  }
+  const id = Number(claims?.sub ?? claims?.userId ?? claims?.id);
+  if (!Number.isInteger(id) || id <= 0) throw new UnauthorizedException('invalid user id in token');
+  return id;
+}

--- a/services/affiliate-service/src/config/env.validation.ts
+++ b/services/affiliate-service/src/config/env.validation.ts
@@ -1,5 +1,5 @@
 import * as Joi from 'joi';
-export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(16).optional(), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
+export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(32).when('NODE_ENV', { is: 'production', then: Joi.required(), otherwise: Joi.optional() }), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
   METRICS_ENABLED: Joi.boolean().default(true)
   ,
   OTEL_ENABLED: Joi.boolean().default(false)

--- a/services/ai-service/src/ai.service.ts
+++ b/services/ai-service/src/ai.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { getPrisma } from './prisma';
 
 function uid(): string { return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
   const r = Math.random()*16|0, v = c==='x'? r : (r&0x3|0x8); return v.toString(16);
@@ -19,7 +19,7 @@ function cosine(a:number[], b:number[]){ const na=norm(a), nb=norm(b); if(na===0
 
 @Injectable()
 export class AiService {
-  prisma = new PrismaClient();
+  prisma = getPrisma();
   SNAPSHOT_ID = 'model-v1';
 
   async ensureModel(){

--- a/services/ai-service/src/config/env.validation.ts
+++ b/services/ai-service/src/config/env.validation.ts
@@ -1,5 +1,5 @@
 import * as Joi from 'joi';
-export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(16).optional(), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
+export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(32).when('NODE_ENV', { is: 'production', then: Joi.required(), otherwise: Joi.optional() }), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
   METRICS_ENABLED: Joi.boolean().default(true)
   ,
   OTEL_ENABLED: Joi.boolean().default(false)

--- a/services/ai-service/src/prisma.ts
+++ b/services/ai-service/src/prisma.ts
@@ -1,0 +1,8 @@
+import { PrismaClient } from '@prisma/client';
+
+// Single shared PrismaClient for the service (P0-6): per-module/per-request
+// client instantiation exhausts the Postgres connection pool under load.
+let _prisma: PrismaClient | undefined;
+export function getPrisma(): PrismaClient {
+  return (_prisma ??= new PrismaClient());
+}

--- a/services/auth-service/src/config/env.validation.ts
+++ b/services/auth-service/src/config/env.validation.ts
@@ -1,5 +1,5 @@
 import * as Joi from 'joi';
-export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(16).optional(), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
+export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(32).when('NODE_ENV', { is: 'production', then: Joi.required(), otherwise: Joi.optional() }), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
   METRICS_ENABLED: Joi.boolean().default(true)
   ,
   OTEL_ENABLED: Joi.boolean().default(false)

--- a/services/certificate-service/src/auth/roles.guard.ts
+++ b/services/certificate-service/src/auth/roles.guard.ts
@@ -2,6 +2,7 @@ import { CanActivate, ExecutionContext, Injectable, ForbiddenException } from '@
 import * as jwt from 'jsonwebtoken';
 import { Reflector } from '@nestjs/core';
 import { ROLES_KEY } from './roles.decorator';
+import { certSecret } from '../config/secret';
 @Injectable()
 export class RolesGuard implements CanActivate {
   constructor(private reflector: Reflector) {}
@@ -14,7 +15,7 @@ export class RolesGuard implements CanActivate {
     const t = token.replace('Bearer ','').trim();
     if (!t) throw new ForbiddenException('No token');
     try {
-      const payload:any = jwt.verify(t, process.env.CERT_SECRET || 'change_me');
+      const payload:any = jwt.verify(t, certSecret(), { algorithms: ['HS256'] });
       const roles = payload.roles || payload.role || [];
       const ok = (Array.isArray(roles)?roles:[roles]).some((r:string)=> required.includes(r));
       if (!ok) throw new ForbiddenException('Insufficient role');

--- a/services/certificate-service/src/certificate/certificate.service.ts
+++ b/services/certificate-service/src/certificate/certificate.service.ts
@@ -1,14 +1,15 @@
 import * as jwt from 'jsonwebtoken';
 import QRCode from 'qrcode';
+import { certSecret } from '../config/secret';
 
 export class CertificateService {
   async issueCertificate(payload: Record<string, any>) {
-    const token = jwt.sign(payload, process.env.CERT_SECRET || 'change_me', { expiresIn: '365d' });
+    const token = jwt.sign(payload, certSecret(), { expiresIn: '365d', algorithm: 'HS256' });
     const url = `${process.env.CERT_VERIFY_URL || 'https://example.com/verify'}?t=${token}`;
     const qrDataUrl = await QRCode.toDataURL(url);
     return { token, qrDataUrl };
   }
   verify(token: string) {
-    return jwt.verify(token, process.env.CERT_SECRET || 'change_me');
+    return jwt.verify(token, certSecret(), { algorithms: ['HS256'] });
   }
 }

--- a/services/certificate-service/src/config/secret.ts
+++ b/services/certificate-service/src/config/secret.ts
@@ -1,0 +1,12 @@
+/**
+ * Fail-closed accessor for the certificate signing secret. There is no
+ * hardcoded fallback: a missing/short CERT_SECRET is a hard error rather than a
+ * publicly-known default (which previously allowed trivial token forgery).
+ */
+export function certSecret(): string {
+  const s = process.env.CERT_SECRET;
+  if (!s || s.length < 16) {
+    throw new Error('CERT_SECRET is not configured (minimum 16 characters required)');
+  }
+  return s;
+}

--- a/services/challenges-service/package.json
+++ b/services/challenges-service/package.json
@@ -13,6 +13,7 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
+    "jsonwebtoken": "^9.0.2",
     "@arman/observability-sdk": "workspace:*",
     "@nestjs/common": "^10.4.0",
     "@nestjs/core": "^10.4.0",

--- a/services/challenges-service/src/auth/req-user.ts
+++ b/services/challenges-service/src/auth/req-user.ts
@@ -1,0 +1,30 @@
+import { UnauthorizedException } from '@nestjs/common';
+import * as jwt from 'jsonwebtoken';
+
+/**
+ * Numeric user id from a verified Bearer JWT. There is NO x-user-id header or
+ * query fallback (those allowed any caller to act as any user) and NO fallback
+ * secret. JWT_SECRET is required; verification pins HS256. Throws 401 when the
+ * token is missing or invalid.
+ */
+function jwtSecret(): string {
+  const s = process.env.JWT_SECRET;
+  if (!s || s.length < 16) {
+    throw new Error('JWT_SECRET is not configured (minimum 16 characters required)');
+  }
+  return s;
+}
+
+export function userIdFromReq(req: any): number {
+  const auth = (req?.headers?.authorization || '').toString();
+  if (!auth.startsWith('Bearer ')) throw new UnauthorizedException('missing bearer token');
+  let claims: any;
+  try {
+    claims = jwt.verify(auth.slice(7), jwtSecret(), { algorithms: ['HS256'] });
+  } catch {
+    throw new UnauthorizedException('invalid token');
+  }
+  const id = Number(claims?.sub ?? claims?.userId ?? claims?.id);
+  if (!Number.isInteger(id) || id <= 0) throw new UnauthorizedException('invalid user id in token');
+  return id;
+}

--- a/services/challenges-service/src/challenges.controller.ts
+++ b/services/challenges-service/src/challenges.controller.ts
@@ -3,6 +3,7 @@ import { Controller, Get, Post, Req, Body } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { z } from 'zod';
 import { ChallengesService } from './challenges.service';
+import { userIdFromReq } from './auth/req-user';
 
 const joinDto = z.object({ challengeId: z.number().int().positive() });
 const completeDto = z.object({ challengeId: z.number().int().positive() });
@@ -21,14 +22,14 @@ export class ChallengesController {
   @Post('challenges/join')
   async join(@Body() body: any, @Req() req: any) {
     const v = joinDto.parse(body);
-    const userId = Number(req.user?.id || req.headers['x-user-id'] || req.query.userId);
+    const userId = userIdFromReq(req);
     return this.svc.join(v.challengeId, userId);
   }
 
   @Post('challenges/complete')
   async complete(@Body() body: any, @Req() req: any) {
     const v = completeDto.parse(body);
-    const userId = Number(req.user?.id || req.headers['x-user-id'] || req.query.userId);
+    const userId = userIdFromReq(req);
     return this.svc.complete(v.challengeId, userId);
   }
 }

--- a/services/challenges-service/src/config/env.validation.ts
+++ b/services/challenges-service/src/config/env.validation.ts
@@ -1,5 +1,5 @@
 import * as Joi from 'joi';
-export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(16).optional(), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
+export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(32).when('NODE_ENV', { is: 'production', then: Joi.required(), otherwise: Joi.optional() }), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
   METRICS_ENABLED: Joi.boolean().default(true)
   ,
   OTEL_ENABLED: Joi.boolean().default(false)

--- a/services/chat-service/src/chat.service.ts
+++ b/services/chat-service/src/chat.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { getPrisma } from './prisma';
 
 function uid(): string { return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
   const r = Math.random()*16|0, v = c==='x'? r : (r&0x3|0x8); return v.toString(16);
@@ -10,7 +10,7 @@ const MAX_SIZE = 10 * 1024 * 1024; // 10MB
 
 @Injectable()
 export class ChatService {
-  prisma = new PrismaClient();
+  prisma = getPrisma();
 
   async ensureThread(userId: string, coachId: string){
     let t = await this.prisma.thread.findFirst({ where: { userId, coachId } });

--- a/services/chat-service/src/chat/chat-persistence.service.ts
+++ b/services/chat-service/src/chat/chat-persistence.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { getPrisma } from '../prisma';
 
 /**
  * Chat Persistence Service
@@ -7,7 +7,7 @@ import { PrismaClient } from '@prisma/client';
  */
 @Injectable()
 export class ChatPersistenceService {
-  private prisma = new PrismaClient();
+  private prisma = getPrisma();
 
   async saveMessage(data: {
     threadId: string;

--- a/services/chat-service/src/config/env.validation.ts
+++ b/services/chat-service/src/config/env.validation.ts
@@ -1,5 +1,5 @@
 import * as Joi from 'joi';
-export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(16).optional(), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
+export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(32).when('NODE_ENV', { is: 'production', then: Joi.required(), otherwise: Joi.optional() }), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
   METRICS_ENABLED: Joi.boolean().default(true)
   ,
   OTEL_ENABLED: Joi.boolean().default(false)

--- a/services/chat-service/src/prisma.readiness.ts
+++ b/services/chat-service/src/prisma.readiness.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { getPrisma } from './prisma';
 
 @Injectable()
 export class PrismaReadiness {
-  private prisma = new PrismaClient();
+  private prisma = getPrisma();
   async ping(): Promise<boolean> {
     try {
       // SELECT 1; if DB is reachable, it should succeed

--- a/services/chat-service/src/prisma.ts
+++ b/services/chat-service/src/prisma.ts
@@ -1,0 +1,8 @@
+import { PrismaClient } from '@prisma/client';
+
+// Single shared PrismaClient for the service (P0-6): per-module/per-request
+// client instantiation exhausts the Postgres connection pool under load.
+let _prisma: PrismaClient | undefined;
+export function getPrisma(): PrismaClient {
+  return (_prisma ??= new PrismaClient());
+}

--- a/services/coaches-service/src/config/env.validation.ts
+++ b/services/coaches-service/src/config/env.validation.ts
@@ -1,5 +1,5 @@
 import * as Joi from 'joi';
-export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(16).optional(), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
+export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(32).when('NODE_ENV', { is: 'production', then: Joi.required(), otherwise: Joi.optional() }), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
   METRICS_ENABLED: Joi.boolean().default(true)
   ,
   OTEL_ENABLED: Joi.boolean().default(false)

--- a/services/content-service/package.json
+++ b/services/content-service/package.json
@@ -31,6 +31,7 @@
     "@nestjs/common": "^10.3.2",
     "@nestjs/core": "^10.3.2",
     "@nestjs/graphql": "^12.0.0",
+    "jsonwebtoken": "^9.0.2",
     "@nestjs/platform-express": "^10.3.2",
     "graphql": "^16.8.1",
     "reflect-metadata": "^0.1.13",

--- a/services/content-service/src/admin/profile.resolver.ts
+++ b/services/content-service/src/admin/profile.resolver.ts
@@ -2,7 +2,7 @@
 import { Resolver, Mutation, Args, Context, Query } from '@nestjs/graphql';
 import { PrismaClient, ServiceType } from '@prisma/client';
 const prisma = new PrismaClient();
-function ctxRole(ctx:any){ try{ return ctx?.req?.headers?.['x-role']||'guest'; }catch(e){ return 'guest'; } }
+import { ctxRole } from '../auth/ctx';
 function mustAdmin(ctx:any){ if (process.env.SKIP_AUTH==='1') return; if (ctxRole(ctx)!=='admin') throw new Error('forbidden'); }
 
 @Resolver()

--- a/services/content-service/src/admin/survey.resolver.ts
+++ b/services/content-service/src/admin/survey.resolver.ts
@@ -2,7 +2,7 @@
 import { Resolver, Query, Mutation, Args, Context } from '@nestjs/graphql';
 import { PrismaClient, ServiceType } from '@prisma/client';
 const prisma = new PrismaClient();
-function ctxRole(ctx:any){ try{ return ctx?.req?.headers?.['x-role']||'guest'; }catch(e){ return 'guest'; } }
+import { ctxRole } from '../auth/ctx';
 function mustAdmin(ctx:any){ if (process.env.SKIP_AUTH==='1') return; if (ctxRole(ctx)!=='admin') throw new Error('forbidden'); }
 
 @Resolver()

--- a/services/content-service/src/auth/ctx.ts
+++ b/services/content-service/src/auth/ctx.ts
@@ -1,0 +1,36 @@
+import * as jwt from 'jsonwebtoken';
+
+/**
+ * Identity/role helpers for GraphQL resolvers. Identity comes ONLY from a
+ * verified Bearer JWT — never from client-supplied x-user-id / x-role headers
+ * (which allowed impersonation and privilege escalation) and never with a
+ * hardcoded fallback secret (which allowed forgery). JWT_SECRET is required and
+ * verification pins HS256.
+ */
+function jwtSecret(): string {
+  const s = process.env.JWT_SECRET;
+  if (!s || s.length < 16) {
+    throw new Error('JWT_SECRET is not configured (minimum 16 characters required)');
+  }
+  return s;
+}
+
+export function ctxClaims(ctx: any): any | null {
+  const h = ctx?.req?.headers || {};
+  const b = (h['authorization'] || '').toString();
+  if (!b.startsWith('Bearer ')) return null;
+  try {
+    return jwt.verify(b.slice(7), jwtSecret(), { algorithms: ['HS256'] }) as any;
+  } catch {
+    return null;
+  }
+}
+
+export function ctxUser(ctx: any): string | null {
+  const d = ctxClaims(ctx);
+  return d?.sub || d?.userId || null;
+}
+
+export function ctxRole(ctx: any): string {
+  return ctxClaims(ctx)?.role || 'guest';
+}

--- a/services/content-service/src/chat/chat.resolver.ts
+++ b/services/content-service/src/chat/chat.resolver.ts
@@ -4,9 +4,8 @@ import { PrismaClient } from '@prisma/client';
 import { wsBroadcast } from '../main';
 
 const prisma = new PrismaClient();
+import { ctxUser, ctxRole } from '../auth/ctx';
 function now(){ return new Date(); }
-function ctxUser(ctx:any){ try{ return ctx?.req?.headers?.['x-user-id'] || null; }catch(e){ return null; } }
-function ctxRole(ctx:any){ try{ return ctx?.req?.headers?.['x-role'] || 'guest'; }catch(e){ return 'guest'; } }
 function must(ctx:any, roles:string[]){ if (process.env.SKIP_AUTH==='1') return; const r = ctxRole(ctx); if (!roles.includes(r) && r!=='admin') throw new Error('forbidden'); }
 
 @Resolver()

--- a/services/content-service/src/config/env.validation.ts
+++ b/services/content-service/src/config/env.validation.ts
@@ -1,5 +1,5 @@
 import * as Joi from 'joi';
-export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(16).optional(), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
+export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(32).when('NODE_ENV', { is: 'production', then: Joi.required(), otherwise: Joi.optional() }), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
   METRICS_ENABLED: Joi.boolean().default(true)
   ,
   OTEL_ENABLED: Joi.boolean().default(false)

--- a/services/content-service/src/corrective/corrective.resolver.ts
+++ b/services/content-service/src/corrective/corrective.resolver.ts
@@ -5,8 +5,9 @@ import { ConditionType, CorrectiveVideoType } from './entities/condition.entity'
 import { CreateConditionInput } from './dto/create-condition.input';
 import { CreateCorrectiveVideoInput } from './dto/create-corrective-video.input';
 import { SearchCorrectiveInput } from './dto/search-corrective.input';
+import { ctxRole } from '../auth/ctx';
 
-function role(ctx:any){ try { return ctx?.req?.headers?.['x-role'] || 'guest'; } catch { return 'guest'; } }
+function role(ctx:any){ return ctxRole(ctx); }
 function must(ctx:any, roles:string[]){ if (process.env.SKIP_AUTH==='1') return; const r = role(ctx); if (!roles.includes(r) && r!=='admin') throw new Error('forbidden'); }
 
 @Resolver()

--- a/services/content-service/src/media/media.resolver.ts
+++ b/services/content-service/src/media/media.resolver.ts
@@ -3,9 +3,9 @@ import { Resolver, Mutation, Args, Context } from '@nestjs/graphql';
 import { PrismaClient } from '@prisma/client';
 import { Queue } from 'bullmq';
 
+import { ctxUser, ctxRole } from '../auth/ctx';
 const prisma = new PrismaClient();
-function ctxUser(ctx:any){ try{ return ctx?.req?.headers?.['x-user-id'] || null; }catch(e){ return null; } }
-function mustAny(ctx:any, roles:string[]){ const r = ctx?.req?.headers?.['x-role']||'guest'; if (r==='admin') return; if (!roles.includes(r)) throw new Error('forbidden'); }
+function mustAny(ctx:any, roles:string[]){ const r = ctxRole(ctx); if (r==='admin') return; if (!roles.includes(r)) throw new Error('forbidden'); }
 
 @Resolver()
 export class MediaResolver {

--- a/services/content-service/src/nutrition/nutrition.resolver.ts
+++ b/services/content-service/src/nutrition/nutrition.resolver.ts
@@ -3,9 +3,9 @@ import { Resolver, Query, Mutation, Args, Context } from '@nestjs/graphql';
 import { PrismaClient } from '@prisma/client';
 import { NutritionService } from './nutrition.service';
 
+import { ctxUser, ctxRole } from '../auth/ctx';
 const prisma = new PrismaClient();
-function ctxUser(ctx:any){ try{ return ctx?.req?.headers?.['x-user-id'] || null; }catch(e){ return null; } }
-function must(ctx:any, role='admin'){ const r = ctx?.req?.headers?.['x-role']||'guest'; if (process.env.SKIP_AUTH==='1') return; if (r===role) return; if (role==='any' && r!=='guest') return; throw new Error('forbidden'); }
+function must(ctx:any, role='admin'){ const r = ctxRole(ctx); if (process.env.SKIP_AUTH==='1') return; if (r===role) return; if (role==='any' && r!=='guest') return; throw new Error('forbidden'); }
 
 @Resolver()
 export class NutritionResolver {

--- a/services/content-service/src/onboarding/onboarding.resolver.ts
+++ b/services/content-service/src/onboarding/onboarding.resolver.ts
@@ -3,8 +3,8 @@ import { Resolver, Query, Mutation, Args, Context } from '@nestjs/graphql';
 import { PrismaClient, ServiceType } from '@prisma/client';
 import { ScoringService } from '../scoring/scoring.service';
 
+import { ctxUser } from '../auth/ctx';
 const prisma = new PrismaClient();
-function ctxUser(ctx:any){ try{ return ctx?.req?.headers?.['x-user-id'] || null; }catch(e){ return null; } }
 function must(ctx:any){ if (process.env.SKIP_AUTH==='1') return; if (!ctxUser(ctx)) throw new Error('unauthenticated'); }
 
 @Resolver()

--- a/services/content-service/src/onboarding/specialist.resolver.ts
+++ b/services/content-service/src/onboarding/specialist.resolver.ts
@@ -1,10 +1,9 @@
 
 import { Resolver, Query, Mutation, Args, Context } from '@nestjs/graphql';
 import { PrismaClient, ServiceType } from '@prisma/client';
+import { ctxRole } from '../auth/ctx';
 const prisma = new PrismaClient();
 
-function ctxUser(ctx:any){ try{ return ctx?.req?.headers?.['x-user-id'] || null; }catch(e){ return null; } }
-function ctxRole(ctx:any){ try{ return ctx?.req?.headers?.['x-role'] || 'guest'; }catch(e){ return 'guest'; } }
 function mustAny(ctx:any, roles:string[]){ if (process.env.SKIP_AUTH==='1') return; const r = ctxRole(ctx); if (r==='admin') return; if (!roles.includes(r)) throw new Error('forbidden'); }
 
 @Resolver()

--- a/services/content-service/src/onboarding/survey.resolver.ts
+++ b/services/content-service/src/onboarding/survey.resolver.ts
@@ -1,8 +1,9 @@
 
 import { Resolver, Mutation, Args, Context } from '@nestjs/graphql';
 import { PrismaClient } from '@prisma/client';
+import { ctxUser } from '../auth/ctx';
 const prisma = new PrismaClient();
-function uid(ctx:any){ try{ return ctx?.req?.headers?.['x-user-id']||'user-demo'; }catch(e){ return 'user-demo'; } }
+function uid(ctx:any){ const u = ctxUser(ctx); if (!u) throw new Error('unauthenticated'); return u; }
 @Resolver()
 export class SurveyResolver {
   @Mutation(()=> Boolean)

--- a/services/content-service/src/plan/plan.resolver.ts
+++ b/services/content-service/src/plan/plan.resolver.ts
@@ -58,8 +58,13 @@ class ComplexBlockInput {
 @ObjectType() class SessionSimDTO { @Field() sessionId:string; @Field() totalSeconds:number; @Field(() => [BlockSimDTO]) blocks: BlockSimDTO[]; }
 
 
-function ctxRole(ctx:any){ try{ const h = ctx?.req?.headers||{}; const b = (h['authorization']||'').toString(); if (b.startsWith('Bearer ')){ try{ const t = b.slice(7); const d:any = jwt.verify(t, process.env.JWT_SECRET||'dev'); return d?.role||'guest'; }catch(e){} } return h['x-role']||ctx?.role||'guest'; }catch(e){ return 'guest'; } }
-function ctxUser(ctx:any){ try{ const h = ctx?.req?.headers||{}; const b = (h['authorization']||'').toString(); if (b.startsWith('Bearer ')){ try{ const t = b.slice(7); const d:any = jwt.verify(t, process.env.JWT_SECRET||'dev'); return d?.sub||d?.userId||null; }catch(e){} } return h['x-user-id']||ctx?.userId||null; }catch(e){ return null; } }
+// Identity comes ONLY from a verified Bearer JWT. No x-role/x-user-id header
+// fallback (that allowed impersonation) and no 'dev' fallback secret (that
+// allowed forgery). JWT_SECRET is required; verification pins HS256.
+function ctxJwtSecret(){ const s = process.env.JWT_SECRET; if(!s || s.length < 16){ throw new Error('JWT_SECRET is not configured (minimum 16 characters required)'); } return s; }
+function ctxClaims(ctx:any): any | null { const h = ctx?.req?.headers||{}; const b = (h['authorization']||'').toString(); if (!b.startsWith('Bearer ')) return null; try{ return jwt.verify(b.slice(7), ctxJwtSecret(), { algorithms: ['HS256'] }) as any; }catch(e){ return null; } }
+function ctxRole(ctx:any){ return ctxClaims(ctx)?.role || 'guest'; }
+function ctxUser(ctx:any){ const d = ctxClaims(ctx); return d?.sub || d?.userId || null; }
 function mustRole(ctx:any, role:'admin'|'coach'|'user'|'specialist'){ if (process.env.SKIP_AUTH==='1') return; const r = ctxRole(ctx); if (r!==role && r!=='admin') throw new Error('forbidden'); }
 
 

--- a/services/content-service/src/scoring/scoring.resolver.ts
+++ b/services/content-service/src/scoring/scoring.resolver.ts
@@ -3,12 +3,9 @@ import { Resolver, Query, Mutation, Args, Context } from '@nestjs/graphql';
 import { ScoringService } from './scoring.service';
 import { PrismaClient, ServiceType } from '@prisma/client';
 
+import { ctxRole } from '../auth/ctx';
 const prisma = new PrismaClient();
-function ctxUser(ctx:any){ try{ return ctx?.req?.headers?.['x-user-id'] || null; }catch(e){ return null; } 
-}
-function ctxRole(ctx:any){ try{ return ctx?.req?.headers?.['x-role'] || 'guest'; }catch(e){ return 'guest'; } 
-}
-function mustAny(ctx:any, roles:string[]){ if (process.env.SKIP_AUTH==='1') return; const r = ctxRole(ctx); if (r==='admin') return; if (!roles.includes(r)) throw new Error('forbidden'); 
+function mustAny(ctx:any, roles:string[]){ if (process.env.SKIP_AUTH==='1') return; const r = ctxRole(ctx); if (r==='admin') return; if (!roles.includes(r)) throw new Error('forbidden');
 }
 
 @Resolver()
@@ -17,7 +14,7 @@ export class ScoringResolver {
 
   @Mutation(()=> Boolean)
   async upsertWeights(@Args('role') role:ServiceType, @Args('json') json:any, @Context() ctx?: any): Promise<boolean>{
-    const r = ctx?.req?.headers?.['x-role']; if (r!=='admin') throw new Error('forbidden');
+    if (ctxRole(ctx)!=='admin') throw new Error('forbidden');
     await prisma.scoringWeights.upsert({ where:{ role }, update:{ weights: json }, create:{ role, weights: json } });
     return true;
   }

--- a/services/content-service/src/surveys/surveys.resolver.ts
+++ b/services/content-service/src/surveys/surveys.resolver.ts
@@ -3,9 +3,8 @@ import { Resolver, Query, Mutation, Args, Context } from '@nestjs/graphql';
 import { SurveysService } from './surveys.service';
 import { PrismaClient, ServiceType } from '@prisma/client';
 
+import { ctxUser, ctxRole } from '../auth/ctx';
 const prisma = new PrismaClient();
-function ctxUser(ctx:any){ try{ return ctx?.req?.headers?.['x-user-id'] || null; }catch(e){ return null; } }
-function ctxRole(ctx:any){ try{ return ctx?.req?.headers?.['x-role'] || 'guest'; }catch(e){ return 'guest'; } }
 
 @Resolver()
 export class SurveysResolver {

--- a/services/courses-service/package.json
+++ b/services/courses-service/package.json
@@ -14,6 +14,7 @@
     "seed": "ts-node prisma/seed.ts"
   },
   "dependencies": {
+    "jsonwebtoken": "^9.0.2",
     "@arman/observability-sdk": "workspace:*",
     "@nestjs/common": "^10.4.0",
     "@nestjs/core": "^10.4.0",

--- a/services/courses-service/src/auth/req-user.ts
+++ b/services/courses-service/src/auth/req-user.ts
@@ -1,0 +1,30 @@
+import { UnauthorizedException } from '@nestjs/common';
+import * as jwt from 'jsonwebtoken';
+
+/**
+ * Numeric user id from a verified Bearer JWT. There is NO x-user-id header or
+ * query fallback (those allowed any caller to act as any user) and NO fallback
+ * secret. JWT_SECRET is required; verification pins HS256. Throws 401 when the
+ * token is missing or invalid.
+ */
+function jwtSecret(): string {
+  const s = process.env.JWT_SECRET;
+  if (!s || s.length < 16) {
+    throw new Error('JWT_SECRET is not configured (minimum 16 characters required)');
+  }
+  return s;
+}
+
+export function userIdFromReq(req: any): number {
+  const auth = (req?.headers?.authorization || '').toString();
+  if (!auth.startsWith('Bearer ')) throw new UnauthorizedException('missing bearer token');
+  let claims: any;
+  try {
+    claims = jwt.verify(auth.slice(7), jwtSecret(), { algorithms: ['HS256'] });
+  } catch {
+    throw new UnauthorizedException('invalid token');
+  }
+  const id = Number(claims?.sub ?? claims?.userId ?? claims?.id);
+  if (!Number.isInteger(id) || id <= 0) throw new UnauthorizedException('invalid user id in token');
+  return id;
+}

--- a/services/courses-service/src/config/env.validation.ts
+++ b/services/courses-service/src/config/env.validation.ts
@@ -1,5 +1,5 @@
 import * as Joi from 'joi';
-export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(16).optional(), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
+export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(32).when('NODE_ENV', { is: 'production', then: Joi.required(), otherwise: Joi.optional() }), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
   METRICS_ENABLED: Joi.boolean().default(true)
   ,
   OTEL_ENABLED: Joi.boolean().default(false)

--- a/services/courses-service/src/courses.controller.ts
+++ b/services/courses-service/src/courses.controller.ts
@@ -3,6 +3,7 @@ import { Controller, Get, Param, Post, Req, Body } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { z } from 'zod';
 import { CoursesService } from './courses.service';
+import { userIdFromReq } from './auth/req-user';
 
 const licenseDto = z.object({ deviceId: z.string().min(4) });
 
@@ -20,7 +21,7 @@ export class CoursesController {
   @Post('courses/:id/license')
   async license(@Param('id') id: string, @Body() body: any, @Req() req: any) {
     const v = licenseDto.parse(body);
-    const userId = Number(req.user?.id || req.headers['x-user-id'] || req.query.userId);
+    const userId = userIdFromReq(req);
     return this.svc.license(Number(id), userId, v.deviceId);
   }
 }

--- a/services/courses-service/src/courses.service.ts
+++ b/services/courses-service/src/courses.service.ts
@@ -14,7 +14,10 @@ export class CoursesService {
   }
 
   async license(courseId: number, userId: number, deviceId: string) {
-    const secret = process.env.LICENSE_SECRET || 'dev-license';
+    const secret = process.env.LICENSE_SECRET;
+    if (!secret || secret.length < 16) {
+      throw new Error('LICENSE_SECRET is not configured (minimum 16 characters required)');
+    }
     const payload = JSON.stringify({ courseId, userId, deviceId, ts: Date.now() });
     const token = CryptoJS.HmacSHA256(payload, secret).toString();
     return { ok: true, token };

--- a/services/marketplace-service/src/config/env.validation.ts
+++ b/services/marketplace-service/src/config/env.validation.ts
@@ -1,5 +1,5 @@
 import * as Joi from 'joi';
-export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(16).optional(), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
+export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(32).when('NODE_ENV', { is: 'production', then: Joi.required(), otherwise: Joi.optional() }), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
   METRICS_ENABLED: Joi.boolean().default(true)
   ,
   OTEL_ENABLED: Joi.boolean().default(false)

--- a/services/monitoring-service/src/config/env.validation.ts
+++ b/services/monitoring-service/src/config/env.validation.ts
@@ -1,5 +1,5 @@
 import * as Joi from 'joi';
-export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(16).optional(), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
+export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(32).when('NODE_ENV', { is: 'production', then: Joi.required(), otherwise: Joi.optional() }), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
   METRICS_ENABLED: Joi.boolean().default(true)
   ,
   OTEL_ENABLED: Joi.boolean().default(false)

--- a/services/notifications-service/src/config/env.validation.ts
+++ b/services/notifications-service/src/config/env.validation.ts
@@ -1,5 +1,5 @@
 import * as Joi from 'joi';
-export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(16).optional(), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
+export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(32).when('NODE_ENV', { is: 'production', then: Joi.required(), otherwise: Joi.optional() }), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
   METRICS_ENABLED: Joi.boolean().default(true)
   ,
   OTEL_ENABLED: Joi.boolean().default(false)

--- a/services/notifications-service/src/notifications.service.ts
+++ b/services/notifications-service/src/notifications.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { getPrisma } from './prisma';
 import hbs from 'handlebars';
 
 function uid(): string { return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
@@ -23,7 +23,7 @@ function buildICS(event:{ uid:string, title:string, startUTC:string, endUTC:stri
 
 @Injectable()
 export class NotificationsService {
-  prisma = new PrismaClient();
+  prisma = getPrisma();
   QUIET_START = Number(process.env.QUIET_START_HOUR||22);
   QUIET_END   = Number(process.env.QUIET_END_HOUR||7);
   MAX_ATTEMPTS = 5;

--- a/services/notifications-service/src/prisma.readiness.ts
+++ b/services/notifications-service/src/prisma.readiness.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { getPrisma } from './prisma';
 
 @Injectable()
 export class PrismaReadiness {
-  private prisma = new PrismaClient();
+  private prisma = getPrisma();
   async ping(): Promise<boolean> {
     try {
       // SELECT 1; if DB is reachable, it should succeed

--- a/services/notifications-service/src/prisma.ts
+++ b/services/notifications-service/src/prisma.ts
@@ -1,0 +1,8 @@
+import { PrismaClient } from '@prisma/client';
+
+// Single shared PrismaClient for the service (P0-6): per-module/per-request
+// client instantiation exhausts the Postgres connection pool under load.
+let _prisma: PrismaClient | undefined;
+export function getPrisma(): PrismaClient {
+  return (_prisma ??= new PrismaClient());
+}

--- a/services/nutrition-service/package.json
+++ b/services/nutrition-service/package.json
@@ -28,6 +28,7 @@
     "sbom": "npx @cyclonedx/cyclonedx-npm --ignore-npm-errors --json --output-file sbom.json"
   },
   "dependencies": {
+    "jsonwebtoken": "^9.0.2",
     "@nestjs/common": "^10.3.2",
     "@nestjs/core": "^10.3.2",
     "@nestjs/graphql": "^12.0.0",

--- a/services/nutrition-service/src/auth/req-user.ts
+++ b/services/nutrition-service/src/auth/req-user.ts
@@ -1,0 +1,30 @@
+import { UnauthorizedException } from '@nestjs/common';
+import * as jwt from 'jsonwebtoken';
+
+/**
+ * Numeric user id from a verified Bearer JWT. There is NO x-user-id header or
+ * query fallback (those allowed any caller to act as any user) and NO fallback
+ * secret. JWT_SECRET is required; verification pins HS256. Throws 401 when the
+ * token is missing or invalid.
+ */
+function jwtSecret(): string {
+  const s = process.env.JWT_SECRET;
+  if (!s || s.length < 16) {
+    throw new Error('JWT_SECRET is not configured (minimum 16 characters required)');
+  }
+  return s;
+}
+
+export function userIdFromReq(req: any): number {
+  const auth = (req?.headers?.authorization || '').toString();
+  if (!auth.startsWith('Bearer ')) throw new UnauthorizedException('missing bearer token');
+  let claims: any;
+  try {
+    claims = jwt.verify(auth.slice(7), jwtSecret(), { algorithms: ['HS256'] });
+  } catch {
+    throw new UnauthorizedException('invalid token');
+  }
+  const id = Number(claims?.sub ?? claims?.userId ?? claims?.id);
+  if (!Number.isInteger(id) || id <= 0) throw new UnauthorizedException('invalid user id in token');
+  return id;
+}

--- a/services/nutrition-service/src/config/env.validation.ts
+++ b/services/nutrition-service/src/config/env.validation.ts
@@ -1,5 +1,5 @@
 import * as Joi from 'joi';
-export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(16).optional(), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
+export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(32).when('NODE_ENV', { is: 'production', then: Joi.required(), otherwise: Joi.optional() }), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
   METRICS_ENABLED: Joi.boolean().default(true)
   ,
   OTEL_ENABLED: Joi.boolean().default(false)

--- a/services/nutrition-service/src/habits/habits.controller.ts
+++ b/services/nutrition-service/src/habits/habits.controller.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { ZodValidationPipe } from '@arman/shared';
 import { HabitsService } from './habits.service';
 import { HabitType } from '@prisma/client';
+import { userIdFromReq } from '../auth/req-user';
 
 const createHabitDto = z.object({
   type: z.nativeEnum(HabitType),
@@ -27,7 +28,7 @@ export class HabitsController {
 
   @Post()
   async create(@Body(new ZodValidationPipe(createHabitDto)) body: any, @Req() req: any) {
-    const userId = Number(req.user?.id || req.headers['x-user-id'] || req.query.userId);
+    const userId = userIdFromReq(req);
     return this.svc.createHabit({
       userId,
       type: body.type,
@@ -49,7 +50,7 @@ export class HabitsController {
 
   @Get('today')
   async today(@Req() req: any) {
-    const userId = Number(req.user?.id || req.headers['x-user-id'] || req.query.userId);
+    const userId = userIdFromReq(req);
     return this.svc.getToday(userId);
   }
 }

--- a/services/nutrition-service/src/hydration/hydration.controller.ts
+++ b/services/nutrition-service/src/hydration/hydration.controller.ts
@@ -4,6 +4,7 @@ import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { HydrationService } from './hydration.service';
 import { ZodValidationPipe } from '@arman/shared';
 import { z } from 'zod';
+import { userIdFromReq } from '../auth/req-user';
 
 const createDto = z.object({
   ml: z.number().int().min(10).max(10000),
@@ -19,9 +20,9 @@ export class HydrationController {
 
   @Post()
   async create(@Body(new ZodValidationPipe(createDto)) body: z.infer<typeof createDto>, @Req() req: any) {
-    const userId = req.user?.id || req.headers['x-user-id'] || req.query.userId;
+    const userId = userIdFromReq(req);
     return this.svc.create({
-      userId: Number(userId),
+      userId,
       ml: body.ml,
       occurredAt: body.occurredAt ? new Date(body.occurredAt) : new Date(),
       source: body.source || 'manual',
@@ -30,9 +31,9 @@ export class HydrationController {
 
   @Get()
   async range(@Query('from') from?: string, @Query('to') to?: string, @Req() req?: any) {
-    const userId = req?.user?.id || req?.headers?.['x-user-id'] || req?.query?.userId;
+    const userId = userIdFromReq(req);
     const fromDt = from ? new Date(from) : new Date(Date.now() - 7*24*3600*1000);
     const toDt = to ? new Date(to) : new Date();
-    return this.svc.getRange(Number(userId), fromDt, toDt);
+    return this.svc.getRange(userId, fromDt, toDt);
   }
 }

--- a/services/nutrition-service/src/wearables/wearables.controller.ts
+++ b/services/nutrition-service/src/wearables/wearables.controller.ts
@@ -6,6 +6,7 @@ import { ZodValidationPipe } from '@arman/shared';
 import * as client from 'prom-client';
 import { HabitsService } from '../habits/habits.service';
 import { HabitType } from '@prisma/client';
+import { userIdFromReq } from '../auth/req-user';
 
 const ingestDto = z.object({
   provider: z.enum(['healthkit','googlefit']),
@@ -31,7 +32,7 @@ export class WearablesController {
 
   @Post('ingest')
   async ingest(@Body(new ZodValidationPipe(ingestDto)) body: any, @Req() req: any) {
-    const userId = Number(req.user?.id || req.headers['x-user-id'] || req.query.userId);
+    const userId = userIdFromReq(req);
     const now = Date.now();
     for (const dp of body.datapoints) {
       const at = new Date(dp.at);

--- a/services/payments-service/src/config/env.validation.ts
+++ b/services/payments-service/src/config/env.validation.ts
@@ -1,5 +1,5 @@
 import * as Joi from 'joi';
-export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(16).optional(), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
+export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(32).when('NODE_ENV', { is: 'production', then: Joi.required(), otherwise: Joi.optional() }), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
   METRICS_ENABLED: Joi.boolean().default(true)
   ,
   OTEL_ENABLED: Joi.boolean().default(false)

--- a/services/payments-service/src/payments.controller.ts
+++ b/services/payments-service/src/payments.controller.ts
@@ -1,6 +1,7 @@
 import { Body, Controller, Get, Post, Query, Req, ForbiddenException } from '@nestjs/common';
 import { PaymentsService } from './payments.service';
 import { subjectFromReq } from '@arman/security-middleware';
+import { verifyWebhookSignature } from './security/webhook';
 
 @Controller('payments')
 export class PaymentsController {
@@ -13,7 +14,8 @@ export class PaymentsController {
   }
 
   @Post('webhook')
-  webhook(@Body() body:{ provider:string, eventId:string, type:string, payload:any }){
+  webhook(@Req() req:any, @Body() body:{ provider:string, eventId:string, type:string, payload:any }){
+    verifyWebhookSignature(req, body);
     return this.svc.webhook(body.provider, body.eventId, body.type, body.payload);
   }
 

--- a/services/payments-service/src/security/webhook.ts
+++ b/services/payments-service/src/security/webhook.ts
@@ -1,0 +1,36 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+import { UnauthorizedException, BadRequestException } from '@nestjs/common';
+
+/**
+ * Verify an inbound PSP webhook before any state change (P0-4). The callback is
+ * authenticated by an HMAC-SHA256 signature (hex, `x-signature` header) over the
+ * canonical JSON body using PAYMENTS_WEBHOOK_SECRET. Comparison is constant-time.
+ * In production a missing secret is a hard failure (fail-closed); outside
+ * production verification is skipped so local/test flows work.
+ */
+export function verifyWebhookSignature(req: any, body: unknown): void {
+  const secret = process.env.PAYMENTS_WEBHOOK_SECRET;
+  if (!secret) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new UnauthorizedException('payments webhook secret is not configured');
+    }
+    return; // dev/test: verification disabled
+  }
+  const provided = (req?.headers?.['x-signature'] || '').toString();
+  if (!provided) throw new BadRequestException('payments webhook signature missing');
+  const expected = createHmac('sha256', secret).update(stableStringify(body)).digest('hex');
+  const a = Buffer.from(provided, 'hex');
+  const b = Buffer.from(expected, 'hex');
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
+    throw new UnauthorizedException('payments webhook signature invalid');
+  }
+}
+
+/** Deterministic JSON (sorted keys) so signer and verifier agree byte-for-byte. */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`;
+}

--- a/services/predictive-service/src/config/env.validation.ts
+++ b/services/predictive-service/src/config/env.validation.ts
@@ -1,5 +1,5 @@
 import * as Joi from 'joi';
-export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(16).optional(), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
+export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(32).when('NODE_ENV', { is: 'production', then: Joi.required(), otherwise: Joi.optional() }), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
   METRICS_ENABLED: Joi.boolean().default(true)
   ,
   OTEL_ENABLED: Joi.boolean().default(false)

--- a/services/users-service/src/config/env.validation.ts
+++ b/services/users-service/src/config/env.validation.ts
@@ -1,5 +1,5 @@
 import * as Joi from 'joi';
-export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(16).optional(), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
+export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(32).when('NODE_ENV', { is: 'production', then: Joi.required(), otherwise: Joi.optional() }), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
   METRICS_ENABLED: Joi.boolean().default(true)
   ,
   OTEL_ENABLED: Joi.boolean().default(false)

--- a/services/vip-service/src/config/env.validation.ts
+++ b/services/vip-service/src/config/env.validation.ts
@@ -1,5 +1,5 @@
 import * as Joi from 'joi';
-export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(16).optional(), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
+export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(32).when('NODE_ENV', { is: 'production', then: Joi.required(), otherwise: Joi.optional() }), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
   METRICS_ENABLED: Joi.boolean().default(true)
   ,
   OTEL_ENABLED: Joi.boolean().default(false)

--- a/services/workouts-service/src/config/env.validation.ts
+++ b/services/workouts-service/src/config/env.validation.ts
@@ -1,5 +1,5 @@
 import * as Joi from 'joi';
-export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(16).optional(), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
+export const envValidationSchema = Joi.object({ NODE_ENV: Joi.string().valid('development','test','production').default('development'), PORT: Joi.number().default(3000), DATABASE_URL: Joi.string().uri().optional(), JWT_SECRET: Joi.string().min(32).when('NODE_ENV', { is: 'production', then: Joi.required(), otherwise: Joi.optional() }), CORS_ORIGIN: Joi.string().allow('*').default('*'), RATE_LIMIT_TTL: Joi.number().default(60), RATE_LIMIT_LIMIT: Joi.number().default(100)   ,
   METRICS_ENABLED: Joi.boolean().default(true)
   ,
   OTEL_ENABLED: Joi.boolean().default(false)


### PR DESCRIPTION
Remediation of the P0/P1 findings from `FINAL-CERTIFICATION.md` (PR #48). Hardens in place — no services deleted. Each fix is one logical commit; modified services typecheck clean (0 errors).

## What
- [x] Security: **4 of 6 P0 closed** + P1-5 (evidence below)
- [x] Unit/Integration/E2E tests: CI unblocked (valid MinIO tag, Playwright title, lockfile)
- [ ] DB migrations — P0-5 pending (needs live Postgres / decommission decision)
- [x] Docs: certification + remediation plan already on PR #48

### P0 closed
1. **P0-1 broken access control** — removed all `x-user-id`/`x-role` header-trust: content-service (11 resolvers → shared `src/auth/ctx.ts`, JWT-verified) and 4 controllers (courses/nutrition/affiliate/challenges → `userIdFromReq()`). Zero trusted-header auth remains repo-wide.
2. **P0-2 optional JWT_SECRET** — required in production across 17 services (incl. active ai/chat/monitoring/notifications/predictive).
3. **P0-3 fallback secrets** — removed `'change_me'`/`'dev'`/`'dev-license'`; fail-closed accessors; HS256 pinned (**P1-5**).
4. **P0-4 unsigned payments webhook** — HMAC-SHA256 verification, fail-closed in prod.

### P1 / CI
- Pinned a real MinIO image tag (the `integration` job died on `manifest unknown`).
- Fixed the Playwright title assertion (the `e2e` failure — site title is Persian).
- Refreshed the lockfile for the newly-declared `jsonwebtoken` deps.

### Remaining (tracked, not in this PR yet)
- **P0-6** `new PrismaClient()` → singleton: 8 files in active services + ~35 in deprecated (content-service alone = 27).
- **P0-5** migrations + `db push` fallback: needs a live Postgres to generate migrations.
- Recommended: fix active-service P0-6 next, then decommission the deprecated services (which neutralizes their P0-5/P0-6) rather than harden retiring code.

## How to test
```
pnpm install --frozen-lockfile
# per modified service, e.g.:
cd services/content-service && npx prisma generate && npx tsc -p tsconfig.build.json --noEmit   # 0 errors
grep -rn "x-user-id\|x-role" services --include=*.ts   # only comments/helpers remain
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WeGuFhBBLsbdDzK1HwYUaJ)_